### PR TITLE
Add Support for Setting the Parameter Group Family

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "main" {
 
 resource "aws_db_parameter_group" "main" {
   name   = var.postgresql_name
-  family = "postgres${element(split(".", var.postgresql_version), 0)}"
+  family = length(var.postgresql_parameter_group_family) > 0 ? var.postgresql_parameter_group_family : "postgres${element(split(".", var.postgresql_version), 0)}"
   tags = {
     Name            = var.postgresql_name
     OwnerList       = var.postgresql_owner

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,8 @@ variable "postgresql_backup_window" {
   default     = "03:30-05:00"
   description = "Window in which instance snapshots will be created as backups"
 }
+variable "postgresql_parameter_group_family" {
+  type        = string
+  default     = ""
+  description = "The family for the PostgreSQL instance's parameter group. Is usually tied to the PostgreSQL version. If set to blank string, module will use the first part of the PostgreSQL version to determine the name of the family"
+}


### PR DESCRIPTION
Since older versions (pre 10) of PostgreSQL have a parameter group
family for each minor version, add support for setting a custom
parameter group family for these PostgreSQL versions.

Signed-off-by: Jason Rogena <jason@rogena.me>