### PR TITLE
Support Not Creating Route 53 CNAMES

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -1,4 +1,4 @@
 data "aws_route53_zone" "main" {
-  name = var.postgresql_domain_zone_name
+  count = length(var.postgresql_domain_names) > 0 ? 1 : 0
+  name  = var.postgresql_domain_zone_name
 }
-

--- a/network.tf
+++ b/network.tf
@@ -47,11 +47,10 @@ resource "aws_db_subnet_group" "main" {
 }
 
 resource "aws_route53_record" "main" {
-  zone_id = data.aws_route53_zone.main.zone_id
+  zone_id = data.aws_route53_zone.main[0].zone_id
   count   = length(var.postgresql_domain_names)
   name    = element(var.postgresql_domain_names, count.index)
   type    = "CNAME"
   ttl     = "300"
   records = [aws_db_instance.main.address]
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -81,10 +81,12 @@ variable "postgresql_copy_tags_to_snapshot" {
 variable "postgresql_domain_names" {
   type        = list(string)
   description = "The domain name to assign to the RDS instance (without the zone name)"
+  default     = []
 }
 variable "postgresql_domain_zone_name" {
   type        = string
   description = "The domain zone the RDS instance's domain should be part of"
+  default     = ""
 }
 variable "postgresql_backup_retention_period" {
   type        = number


### PR DESCRIPTION
Some deployments might not want/need CNAMES created for the RDS endpoint
DNS record. Add support for that.

Signed-off-by: Jason Rogena <jason@rogena.me>