### PR TITLE
Add pgstatstatements support

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -31,8 +31,12 @@ resource "aws_db_instance" "main" {
 }
 
 resource "aws_db_parameter_group" "main" {
-  name                        = var.postgresql_name
-  track_activity_query_size   = var.postgresql_track_activity_query_size
+  name                              = var.postgresql_name
+  track_activity_query_size         = var.postgresql_track_activity_query_size
+  pg_stat_statements.max            = var.postgresql_pg_stat_statements_max
+  pg_stat_statements.track          = var.postgresql_pg_stat_statements_track
+  pg_stat_statements.track_utility  = var.postgresql_pg_stat_statements_track_utility
+  pg_stat_statements.save           = var.postgresql_pg_stat_statements_save
   family = length(var.postgresql_parameter_group_family) > 0 ? var.postgresql_parameter_group_family : "postgres${element(split(".", var.postgresql_version), 0)}"
   tags = {
     Name            = var.postgresql_name

--- a/storage.tf
+++ b/storage.tf
@@ -31,7 +31,8 @@ resource "aws_db_instance" "main" {
 }
 
 resource "aws_db_parameter_group" "main" {
-  name   = var.postgresql_name
+  name                        = var.postgresql_name
+  track_activity_query_size   = var.postgresql_track_activity_query_size
   family = length(var.postgresql_parameter_group_family) > 0 ? var.postgresql_parameter_group_family : "postgres${element(split(".", var.postgresql_version), 0)}"
   tags = {
     Name            = var.postgresql_name

--- a/storage.tf
+++ b/storage.tf
@@ -31,13 +31,34 @@ resource "aws_db_instance" "main" {
 }
 
 resource "aws_db_parameter_group" "main" {
-  name                              = var.postgresql_name
-  track_activity_query_size         = var.postgresql_track_activity_query_size
-  pg_stat_statements.max            = var.postgresql_pg_stat_statements_max
-  pg_stat_statements.track          = var.postgresql_pg_stat_statements_track
-  pg_stat_statements.track_utility  = var.postgresql_pg_stat_statements_track_utility
-  pg_stat_statements.save           = var.postgresql_pg_stat_statements_save
+  name   = var.postgresql_name
   family = length(var.postgresql_parameter_group_family) > 0 ? var.postgresql_parameter_group_family : "postgres${element(split(".", var.postgresql_version), 0)}"
+
+  parameter {
+    name  = "track_activity_query_size"
+    value = var.postgresql_track_activity_query_size
+  }
+
+  parameter {
+    name  = "pg_stat_statements.max"
+    value = var.postgresql_pg_stat_statements_max
+  }
+
+  parameter {
+    name  = "pg_stat_statements.track"
+    value = var.postgresql_pg_stat_statements_track
+  }
+
+  parameter {
+    name  = "pg_stat_statements.track_utility"
+    value = var.postgresql_pg_stat_statements_track_utility
+  }
+
+  parameter {
+    name  = "pg_stat_statements.save"
+    value = var.postgresql_pg_stat_statements_save
+  }
+
   tags = {
     Name            = var.postgresql_name
     OwnerList       = var.postgresql_owner

--- a/variables.tf
+++ b/variables.tf
@@ -128,7 +128,7 @@ variable "postgresql_pg_stat_statements_max" {
   default     = 5000
   description = "The maximum number of statements tracked by the pg_stat_statements module"
 }
-variable "pg_stat_statements_track" {
+variable "postgresql_pg_stat_statements_track" {
   type        = string
   default     = "top"
   description = "Controls which statements are counted by the pg_stat_statements module"
@@ -138,7 +138,7 @@ variable "postgresql_pg_stat_statements_track_utility" {
   default     = true
   description = "Controls whether utility commands are tracked by the pg_stat_statements module"
 }
-variable "pg_stat_statements_save" {
+variable "postgresql_pg_stat_statements_save" {
   type        = bool
   default     = true
   description = "Specifies whether to save statement statistics tracked by the pg_stat_statements module across server shutdowns"

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,11 @@ variable "postgresql_alarm_connections_threshold" {
   default     = 120
   description = "The threshold of database connections above which an alarm will be raised"
 }
+variable "postgresql_track_activity_query_size" {
+  type        = number
+  default     = 1024
+  description = "The number of bytes reserved to track the currently executing command for each active session"
+}
 variable "postgresql_alarm_alarm_actions" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,26 @@ variable "postgresql_track_activity_query_size" {
   default     = 1024
   description = "The number of bytes reserved to track the currently executing command for each active session"
 }
+variable "postgresql_pg_stat_statements_max" {
+  type        = number
+  default     = 5000
+  description = "The maximum number of statements tracked by the pg_stat_statements module"
+}
+variable "pg_stat_statements_track" {
+  type        = string
+  default     = "top"
+  description = "Controls which statements are counted by the pg_stat_statements module"
+}
+variable "postgresql_pg_stat_statements_track_utility" {
+  type        = bool
+  default     = true
+  description = "Controls whether utility commands are tracked by the pg_stat_statements module"
+}
+variable "pg_stat_statements_save" {
+  type        = bool
+  default     = true
+  description = "Specifies whether to save statement statistics tracked by the pg_stat_statements module across server shutdowns"
+}
 variable "postgresql_alarm_alarm_actions" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
For us to be able to use [pgstatstatments](https://www.postgresql.org/docs/9.4/pgstatstatements.html) on AWS, we need to edit our AWS parameter group, and change this:

track_activity_query_size = 2048 (increase maximum length before which queries are truncated)
pg_stat_statements.track = ALL (track all statements, including those inside stored procedures)

This is according to: https://forums.aws.amazon.com/thread.jspa?messageID=548468

This PR adds support for the above.

This PR is meant to be part of fixing: https://github.com/onaio/reveal-frontend/issues/613