### PR TITLE
Updates the Default Apply Method for the Parameter Group

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,6 @@ variable "postgresql_publicly_accessible" {
 }
 variable "postgresql_parameter_group_apply_method" {
   type        = string
-  default     = "immediate"
+  default     = "pending-reboot"
   description = "Can be either 'immediate' or 'pending-reboot'. Specifies when the parameter group parameters should be applied to the database."
 }


### PR DESCRIPTION
Updates the default apply method for the parameter group to
`pending-reboot` since `immediate` isn't supported for some parameters.

Signed-off-by: Jason Rogena <jason@rogena.me>