### PR TITLE
Export all RDS instances

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
-output "postgres_aws_db_instance_arn" {
-  value       = aws_db_instance.blank-database[0].arn
+output "postgres_aws_db_instance_arns" {
+  value       = aws_db_instance.blank-database.*.arn
   description = "Outputs the Amazon Resource Name (ARN) of instance incase we need to create a read replica of this instance"
 }
 


### PR DESCRIPTION
Ensures we do not encounter "Error: Invalid index" when you create an
RDS instance from a snapshot.

    Error: Invalid index

      on ../../../../modules/providers/aws/postgresql/output.tf line 2, in output "postgres_aws_db_instance_arn":
       2:   value       = aws_db_instance.blank-database[0].arn
        |----------------
        | aws_db_instance.blank-database is empty tuple

    The given key does not identify an element in this collection value.

Using the aws_db_instance.blank-database.*.arn ensures if we have zero
instances to expose, it will not fail with the above error.