### PR TITLE
Pins Minimum AWS Provider Version to 3.8.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,8 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.8.0"
     }
   }
 }


### PR DESCRIPTION
Pin the minimum AWS provider version to 3.8.0. Minimum provider version
pinning recommended in the Terraform docs:

  Each module should at least declare the minimum provider version it is known to work with, using the >= version constraint syntax [1].

1 - https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions